### PR TITLE
Fix deprecated EOS.undent with newer Brew versions

### DIFF
--- a/arduino-mk.rb
+++ b/arduino-mk.rb
@@ -13,7 +13,7 @@ class ArduinoMk < Formula
         prefix.install Dir["*"]
     end
 
-    def caveats; <<~EOS.undent
+    def caveats; <<~EOS
         To use the Arduino-Makefile, please add the following into your per-project Makefile
 
             include #{opt_prefix}/Arduino.mk


### PR DESCRIPTION
brew say 'Error: Calling <<-EOS.undent is disabled!'

```
% brew install arduino-mk
==> Installing arduino-mk from sudar/arduino-mk
==> Downloading https://github.com/sudar/Arduino-Makefile/archive/1.5.2.tar.gz
==> Downloading from https://codeload.github.com/sudar/Arduino-Makefile/tar.gz/1.5.
######################################################################## 100.0%
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/sudar/homebrew-arduino-mk/arduino-mk.rb:22:in `caveats'
Please report this to the sudar/arduino-mk tap!
Or, even better, submit a PR to fix it!
```

My Environments:

```
% brew -v
Homebrew 1.6.8
Homebrew/homebrew-core (git revision 4564a; last commit 2018-06-12)
% ruby -v
ruby 2.3.3p222 (2016-11-21 revision 56859) [universal.x86_64-darwin17]
% sw_vers
ProductName:	Mac OS X
ProductVersion:	10.13.4
BuildVersion:	17E202
%
```
